### PR TITLE
HFix, HCofree

### DIFF
--- a/src/Data/HFunctor.hs
+++ b/src/Data/HFunctor.hs
@@ -27,6 +27,8 @@ module Data.HFunctor (
   -- * 'HFunctor' Combinators
   , HLift(..), retractHLift
   , HFree(..), foldHFree, retractHFree
+  , HFix (..), foldHFix, fixJoin
+  , HCofree (..), foldHCofree, fixUnwrap, annotate
   ) where
 
 import           Control.Applicative.Backwards
@@ -271,6 +273,53 @@ instance HFunctor t => HFunctor (HFree t) where
         go = \case
           HReturn x -> HReturn (f x)
           HJoin   x -> HJoin (hmap go x)
+
+newtype HFix t a = HFix (t (HFix t) a)
+
+foldHFix
+  :: forall t f. HFunctor t
+  => (t f ~> f)
+  -> (HFix t ~> f)
+foldHFix f = go where
+    go :: HFix t ~> f
+    go (HFix t) = f (hmap go t)
+
+deriving instance Functor (t (HFix t)) => Functor (HFix t)
+
+fixJoin :: HFunctor t => HFix t ~> HFree t f
+fixJoin = foldHFix HJoin
+
+data HCofree t f a = (:<)
+  { hextract :: f a
+  , hunwrap  :: t (HCofree t f) a
+  }
+
+deriving instance (Functor f, Functor (t (HCofree t f))) => Functor (HCofree t f)
+
+foldHCofree
+    :: forall t f g. HFunctor t
+    => (forall x. f x -> t g x -> g x)
+    -> (HCofree t f ~> g)
+foldHCofree f = go
+  where
+    go :: HCofree t f ~> g
+    go (a :< t) = f a (hmap go t)
+
+fixUnwrap :: HFunctor t => HCofree t f ~> HFix t
+fixUnwrap = foldHCofree (const HFix)
+
+annotate
+  :: forall t f. HFunctor t
+  => (t f ~> f) -- Replace by `retract`?
+  -> HFix t ~> HCofree t f
+annotate f = foldHFix (\r -> f (hmap hextract r) :< r)
+
+instance HFunctor t => HFunctor (HCofree t) where
+  hmap :: forall f g. (f ~> g) -> (HCofree t f ~> HCofree t g)
+  hmap f = go
+    where
+      go :: HCofree t f ~> HCofree t g
+      go (fa :< t) = (f fa :< hmap go t)
 
 -- | A typeclass for 'HFunctor's where you can "inject" an @f a@ into a @t
 -- f a@:


### PR DESCRIPTION
This implements `HFix` and `HCofree`. This PR is more a request for feedback than an actual proposal. Much of the contents of this library goes way over my head, and you say explicitly that the goal of the library is _not_ to implement the fixpoint.

That said, we have been using `HFix` and `HCofree` pretty successfully, and it might be useful to merge upstream. In particular, we describe programs with a GADT which looks a bit like
```haskell
data Foo f k where
  Foo :: f k -> Foo ('S k)
```
`HFix Foo` makes it a recursive data structure, and the `HCofree Foo SNat` is that recursive data annotated with witnesses.
If you do think that this fits the goal of `functor-combinators`, let me know and I'll clean this up so it can be merged.