### PR TITLE
Fixes for GHC 9

### DIFF
--- a/functor-combinators.cabal
+++ b/functor-combinators.cabal
@@ -1,0 +1,207 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           functor-combinators
+version:        0.3.6.0
+synopsis:       Tools for functor combinator-based program design
+description:    Tools for working with /functor combinators/: types that take functors (or
+                other indexed types) and returns a new functor that "enhances" or "mixes"
+                them in some way.  In the process, you can design featureful programs by
+                composing smaller "primitives" using basic unversal combinators.
+                .
+                The main entry point is "Data.Functor.Combinators", but more fine-grained
+                functionality and extra combinators (some of them re-implementations for
+                compatibility) are available in other modules as well.
+                .
+                This library does not define new functor combinators for the most part,
+                but rather re-exports them from different parts of the Haskell ecosystem
+                and provides a uniform interface.
+                .
+                See the README for a quick overview, and also
+                <https://blog.jle.im/entry/functor-combinatorpedia.html> for an in-depth
+                dive into the motivation behind functor combinator-driven development,
+                examples of the functor combinators in this library, and details about how
+                to use these abstractions!
+category:       Data
+homepage:       https://github.com/mstksg/functor-combinators#readme
+bug-reports:    https://github.com/mstksg/functor-combinators/issues
+author:         Justin Le
+maintainer:     justin@jle.im
+copyright:      (c) Justin Le 2019
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+tested-with:
+    GHC >= 8.6
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/mstksg/functor-combinators
+
+library
+  exposed-modules:
+      Control.Applicative.ListF
+      Control.Applicative.Step
+      Control.Monad.Freer.Church
+      Control.Natural.IsoF
+      Data.Functor.Apply.Free
+      Data.Functor.Combinator
+      Data.Functor.Combinator.Unsafe
+      Data.Functor.Contravariant.Conclude
+      Data.Functor.Contravariant.Decide
+      Data.Functor.Contravariant.Divise
+      Data.Functor.Contravariant.Divisible.Free
+      Data.Functor.Contravariant.Night
+      Data.Functor.Invariant.DecAlt
+      Data.Functor.Invariant.DivAp
+      Data.Functor.Invariant.Night
+      Data.HBifunctor
+      Data.HBifunctor.Associative
+      Data.HBifunctor.Tensor
+      Data.HFunctor
+      Data.HFunctor.Chain
+      Data.HFunctor.Final
+      Data.HFunctor.HTraversable
+      Data.HFunctor.Interpret
+      Data.HFunctor.Route
+  other-modules:
+      Data.HFunctor.Internal
+      Data.HFunctor.Chain.Internal
+      Data.HBifunctor.Tensor.Internal
+  hs-source-dirs:
+      src
+  default-extensions:
+      AllowAmbiguousTypes
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      EmptyCase
+      ExistentialQuantification
+      ExplicitNamespaces
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PatternSynonyms
+      QuantifiedConstraints
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeInType
+      TypeOperators
+      UndecidableInstances
+      UndecidableSuperClasses
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Wredundant-constraints -Werror=incomplete-patterns
+  build-depends:
+      assoc
+    , base >=4.12 && <5
+    , bifunctors
+    , comonad
+    , constraints
+    , containers
+    , contravariant
+    , deriving-compat
+    , free
+    , invariant
+    , kan-extensions
+    , mmorph
+    , mtl
+    , natural-transformation
+    , nonempty-containers
+    , pointed
+    , profunctors
+    , semigroupoids
+    , sop-core
+    , tagged
+    , these
+    , transformers
+    , trivial-constraint >=0.5
+    , vinyl
+  default-language: Haskell2010
+
+test-suite functor-combinators-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Tests.HBifunctor
+      Tests.HFunctor
+      Tests.Util
+      Paths_functor_combinators
+  hs-source-dirs:
+      test
+  default-extensions:
+      AllowAmbiguousTypes
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      EmptyCase
+      ExistentialQuantification
+      ExplicitNamespaces
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PatternSynonyms
+      QuantifiedConstraints
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeInType
+      TypeOperators
+      UndecidableInstances
+      UndecidableSuperClasses
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Wredundant-constraints -Werror=incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.12 && <5
+    , bifunctors
+    , dependent-sum
+    , free
+    , functor-combinators
+    , hedgehog >=0.6
+    , nonempty-containers
+    , semigroupoids
+    , tasty
+    , tasty-hedgehog
+    , transformers
+    , trivial-constraint >=0.5
+  default-language: Haskell2010

--- a/src/Control/Natural/IsoF.hs
+++ b/src/Control/Natural/IsoF.hs
@@ -70,7 +70,7 @@ isoF
     :: f ~> g
     -> g ~> f
     -> f <~> g
-isoF = dimap
+isoF f g a = dimap f g a
 
 -- | An isomorphism between two functors that are coercible/have the same
 -- internal representation.  Useful for newtype wrappers.

--- a/src/Data/HFunctor.hs
+++ b/src/Data/HFunctor.hs
@@ -556,7 +556,7 @@ instance HBind Coyoneda where
     hbind f (Coyoneda g x) = g <$> f x
 
 instance HBind Ap where
-    hbind = runAp
+    hbind f x = runAp f x
 
 instance HBind ListF where
     hbind f = foldMap f . runListF
@@ -614,25 +614,25 @@ instance HBind (M1 i c) where
     hbind f (M1 x) = f x
 
 instance HBind Alt.Alt where
-    hbind = Alt.runAlt
+    hbind f x = Alt.runAlt f x
 
 instance HBind Free where
-    hbind = interpretFree
+    hbind f x = interpretFree f x
 
 instance HBind Free1 where
-    hbind = interpretFree1
+    hbind f x = interpretFree1 f x
 
 instance HBind FA.Ap where
-    hbind = FA.runAp
+    hbind f x = FA.runAp f x
 
 instance HBind FAF.Ap where
-    hbind = FAF.runAp
+    hbind f x = FAF.runAp f x
 
 instance HBind IdentityT where
     hbind f = f . runIdentityT
 
 instance HBind Lift where
-    hbind = elimLift point
+    hbind f x = elimLift point f x
 
 instance HBind MaybeApply where
     hbind f = either f point . runMaybeApply

--- a/src/Data/HFunctor/Final.hs
+++ b/src/Data/HFunctor/Final.hs
@@ -298,7 +298,7 @@ instance HFunctor (Final c) where
     hmap f x = Final $ \r -> runFinal x (r . f)
 
 instance Inject (Final c) where
-    inject x = Final ($ x)
+    inject x = Final $ \f -> f x
 
 instance c f => Interpret (Final c) f where
     retract x = runFinal x id

--- a/src/Data/HFunctor/Internal.hs
+++ b/src/Data/HFunctor/Internal.hs
@@ -136,11 +136,11 @@ class HFunctor t where
 class HBifunctor (t :: (k -> Type) -> (k -> Type) -> k -> Type) where
     -- | Swap out the first transformed functor.
     hleft  :: f ~> j -> t f g ~> t j g
-    hleft = (`hbimap` id)
+    hleft f x = hbimap f id x
 
     -- | Swap out the second transformed functor.
     hright :: g ~> l -> t f g ~> t f l
-    hright = hbimap id
+    hright f x = hbimap id f x
 
     -- | Swap out both transformed functors at the same time.
     hbimap :: f ~> j -> g ~> l -> t f g ~> t j l
@@ -206,14 +206,14 @@ instance Semigroup (NDL a) where
     NDL x <> NDL y = NDL (x . toList . y)
 
 instance HFunctor Coyoneda where
-    hmap = hoistCoyoneda
+    hmap f x = hoistCoyoneda f x
 
 -- | @since 0.3.0.0
 instance HFunctor CCY.Coyoneda where
     hmap f (CCY.Coyoneda g x) = CCY.Coyoneda g (f x)
 
 instance HFunctor Ap where
-    hmap = hoistAp
+    hmap f x = hoistAp f x
 
 instance HFunctor ListF where
     hmap f (ListF xs) = ListF (map f xs)
@@ -231,7 +231,7 @@ instance HFunctor (NEMapF k) where
     hmap f (NEMapF xs) = NEMapF (fmap f xs)
 
 instance HFunctor Alt.Alt where
-    hmap = Alt.hoistAlt
+    hmap f x = Alt.hoistAlt f x
 
 -- | @since 0.3.6.0
 instance HFunctor Alt.AltF where
@@ -249,37 +249,37 @@ instance HFunctor Flagged where
     hmap f (Flagged b x) = Flagged b (f x)
 
 instance HFunctor Free where
-    hmap = hoistFree
+    hmap f x = hoistFree f x
 
 instance HFunctor Free1 where
-    hmap = hoistFree1
+    hmap f x = hoistFree1 f x
 
 -- | Note that there is no 'Data.HFunctor.Interpret.Interpret' or
 -- 'Data.HFunctor.Bind' instance, because 'Data.HFunctor.inject' requires
 -- @'Functor' f@.
 instance HFunctor MC.F where
-    hmap = MC.hoistF
+    hmap f x = MC.hoistF f x
 
 -- | Note that there is no 'Data.HFunctor.Interpret.Interpret' or
 -- 'Data.HFunctor.Bind' instance, because 'Data.HFunctor.inject' requires
 -- @'Functor' f@.
 instance HFunctor MaybeT where
-    hmap f = mapMaybeT f
+    hmap f x = mapMaybeT f x
 
 instance HFunctor Yoneda where
     hmap f x = Yoneda $ f . runYoneda x
 
 instance HFunctor FA.Ap where
-    hmap = FA.hoistAp
+    hmap f x = FA.hoistAp f x
 
 instance HFunctor FAF.Ap where
-    hmap = FAF.hoistAp
+    hmap f x = FAF.hoistAp f x
 
 instance HFunctor IdentityT where
-    hmap = mapIdentityT
+    hmap f x = mapIdentityT f x
 
 instance HFunctor Lift where
-    hmap = mapLift
+    hmap f x = mapLift f x
 
 instance HFunctor MaybeApply where
     hmap f (MaybeApply x) = MaybeApply (first f x)
@@ -291,10 +291,10 @@ instance HFunctor WrappedApplicative where
     hmap f (WrapApplicative x) = WrapApplicative (f x)
 
 instance HFunctor (ReaderT r) where
-    hmap = mapReaderT
+    hmap f x = mapReaderT f x
 
 instance HFunctor Tagged where
-    hmap _ = coerce
+    hmap _ x = coerce x
 
 instance HFunctor Reverse where
     hmap f (Reverse x) = Reverse (f x)
@@ -309,13 +309,13 @@ instance HFunctor (M1 i c) where
     hmap f (M1 x) = M1 (f x)
 
 instance HFunctor Void2 where
-    hmap _ = coerce
+    hmap _ x = coerce x
 
 instance HFunctor (EnvT e) where
     hmap f (EnvT e x) = EnvT e (f x)
 
 instance HFunctor Rec where
-    hmap = rmap
+    hmap f x = rmap f x
 
 instance HFunctor CoRec where
     hmap f (CoRec x) = CoRec (f x)
@@ -329,7 +329,7 @@ instance HFunctor SOP.NS where
     hmap f = SOP.cata_NS (SOP.Z . f) SOP.S
 
 instance HFunctor (Joker f) where
-    hmap _ = coerce
+    hmap _ x = coerce x
 
 instance HFunctor (Void3 f) where
     hmap _ = \case {}
@@ -348,14 +348,14 @@ instance HBifunctor Product where
     hbimap f g (Pair x y) = Pair (f x) (g y)
 
 instance HBifunctor Day where
-    hleft  = D.trans1
-    hright = D.trans2
+    hleft f x = D.trans1 f x
+    hright f x = D.trans2 f x
     hbimap f g (Day x y z) = Day (f x) (g y) z
 
 -- | @since 0.3.0.0
 instance HBifunctor CD.Day where
-    hleft  = CD.trans1
-    hright = CD.trans2
+    hleft f x = CD.trans1 f x
+    hright f x = CD.trans2 f x
     hbimap f g (CD.Day x y z) = CD.Day (f x) (g y) z
 
 -- | @since 0.3.4.0
@@ -367,8 +367,8 @@ instance HBifunctor IN.Night where
 
 -- | @since 0.3.0.0
 instance HBifunctor Night where
-    hleft  = N.trans1
-    hright = N.trans2
+    hleft f x = N.trans1 f x
+    hright f x = N.trans2 f x
     hbimap f g (Night x y z) = Night (f x) (g y) z
 
 instance HBifunctor (:+:) where

--- a/src/Data/HFunctor/Interpret.hs
+++ b/src/Data/HFunctor/Interpret.hs
@@ -427,7 +427,7 @@ instance Applicative f => Interpret Ap.Ap f where
     retract   = \case
       Ap.Pure x  -> pure x
       Ap.Ap x xs -> x <**> retract xs
-    interpret = Ap.runAp
+    interpret f x = Ap.runAp f x
 
 -- | A free 'Plus'
 instance Plus f => Interpret ListF f where
@@ -491,7 +491,7 @@ instance Plus f => Interpret (These1 g) f where
 
 -- | A free 'Alternative'
 instance Alternative f => Interpret Alt.Alt f where
-    interpret = Alt.runAlt
+    interpret f x = Alt.runAlt f x
 
 instance Plus g => Interpret ((:*:) g) f where
     retract (_ :*: y) = y
@@ -528,22 +528,22 @@ instance Interpret (M1 i c) f where
 -- | A free 'Monad'
 instance Monad f => Interpret Free f where
     retract   = retractFree
-    interpret = interpretFree
+    interpret f x = interpretFree f x
 
 -- | A free 'Bind'
 instance Bind f => Interpret Free1 f where
     retract   = retractFree1
-    interpret = interpretFree1
+    interpret f x = interpretFree1 f x
 
 -- | A free 'Applicative'
 instance Applicative f => Interpret FA.Ap f where
     retract   = FA.retractAp
-    interpret = FA.runAp
+    interpret f x = FA.runAp f x
 
 -- | A free 'Applicative'
 instance Applicative f => Interpret FAF.Ap f where
     retract   = FAF.retractAp
-    interpret = FAF.runAp
+    interpret f x = FAF.runAp f x
 
 instance Interpret IdentityT f where
     retract = coerce
@@ -552,7 +552,7 @@ instance Interpret IdentityT f where
 -- | A free 'Pointed'
 instance Pointed f => Interpret Lift f where
     retract   = elimLift point id
-    interpret = elimLift point
+    interpret f x = elimLift point f x
 
 -- | A free 'Pointed'
 instance Pointed f => Interpret MaybeApply f where


### PR DESCRIPTION
Due to simplified subsumption I needed to eta-expand a bunch of definitions to get this to build on GHC 9.

I have also needed to check in a `.cabal` file so I can use this fork with `source-repository-package` in Cabal, but you might want to ignore that from this PR.